### PR TITLE
Replace `print` with `tf.print` to prevent side effects in `tf.function`

### DIFF
--- a/unsup_flow/tf/relaxed_tf_function_test.py
+++ b/unsup_flow/tf/relaxed_tf_function_test.py
@@ -13,14 +13,14 @@ from unsup_flow.tf.relaxed_tf_function import relaxed_tf_function
     lambda x: [s if s in [2, 3, 4] and i > 0 else None for i, s in enumerate(x.shape)]
 )
 def tf_func(dict_of_tensors, step, **kwargs):
-    print(
+    tf.print(
         "####################################### Tracing #########################################"
     )
-    print(kwargs)
-    print({k: id(v) for k, v in kwargs.items()})
-    print(dict_of_tensors)
-    print(step)
-    print([v for k, v in kwargs.items() if len(k) > 1])
+    tf.print(kwargs)
+    tf.print({k: id(v) for k, v in kwargs.items()})
+    tf.print(dict_of_tensors)
+    tf.print(step)
+    tf.print([v for k, v in kwargs.items() if len(k) > 1])
     return (
         dict_of_tensors["c"]
         + dict_of_tensors["ccc"]
@@ -33,14 +33,14 @@ def tf_func(dict_of_tensors, step, **kwargs):
     lambda x: [s if s in [2, 3, 4] and i > 0 else None for i, s in enumerate(x.shape)]
 )
 def tf_func2(dict_of_tensors, step, **kwargs):
-    print(
+    tf.print(
         "####################################### Tracing 2 #########################################"
     )
-    print(kwargs)
-    print({k: id(v) for k, v in kwargs.items()})
-    print(dict_of_tensors)
-    print(step)
-    print([v for k, v in kwargs.items() if len(k) > 1])
+    tf.print(kwargs)
+    tf.print({k: id(v) for k, v in kwargs.items()})
+    tf.print(dict_of_tensors)
+    tf.print(step)
+    tf.print([v for k, v in kwargs.items() if len(k) > 1])
     return dict_of_tensors["c"] + step + sum(v for k, v in kwargs.items() if len(k) > 1)
 
 


### PR DESCRIPTION
### Description:

This PR updates `tf_func` and `tf_func2` by replacing all Python `print` statements with `tf.print`. Since these functions are decorated with `@relaxed_tf_function` (a wrapper for TensorFlow’s `tf.function`), using standard `print` statements can lead to unexpected behavior due to TensorFlow’s tracing mechanism. According to TensorFlow’s documentation:

> Side effects, like printing, […] can behave unexpectedly inside a tf.function, sometimes executing twice or not at all. […] TensorFlow APIs like tf.print […] are the best way to ensure your code will be executed by the TensorFlow runtime with each call. ([Source](https://www.tensorflow.org/guide/function#executing_python_side_effects))

### Changes Made:

•	Replaced all `print` statements with `tf.print`.

This ensures that debug outputs execute consistently and aligns with TensorFlow’s best practices for side-effect management within tf.function.